### PR TITLE
feat: add x-sid header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### 功能
 
-- 处理会话信息：如果 cookie 中包含会话ID（字段为 `sid`），则会将会话ID转发给认证服务获取对应的身份信息，然后传递给业务逻辑层。
+- 处理会话信息：如果 cookie 中包含会话ID（字段为 `sid`），则会将会话ID转发给认证服务获取对应的身份信息，然后传递给业务逻辑层。**新增：如果请求头中包含 `X-SID` 字段，则会优先使用请求头中的值，实现更灵活的内部服务请求。**
 
 - 解析 JWT 凭证：如果 `header` 中包含字段 `Authorization`，且符合 [`Bearer <token>`](https://swagger.io/docs/specification/authentication/bearer-authentication/) 格式 ，则会对其进行 JWT 解码，然后传递给业务逻辑层。
 

--- a/preprocess_test.go
+++ b/preprocess_test.go
@@ -360,6 +360,7 @@ func TestServeHTTP_ByTraceId(t *testing.T) {
 	}
 }
 
+// 测试通过 Cookie 中的 sid 进行认证
 func TestForwardAuth_CookieSid(t *testing.T) {
 	// 创建一个测试服务器来模拟认证服务
 	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -427,6 +428,7 @@ func TestForwardAuth_CookieSid(t *testing.T) {
 	}
 }
 
+// 测试通过请求头中的 X-SID 进行认证
 func TestForwardAuth_HeaderXSid(t *testing.T) {
 	// 创建一个测试服务器来模拟认证服务
 	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -492,6 +494,7 @@ func TestForwardAuth_HeaderXSid(t *testing.T) {
 	}
 }
 
+// 测试没有 sid 时的行为
 func TestForwardAuth_NoSid(t *testing.T) {
 	// 创建一个测试服务器来模拟认证服务
 	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### 功能添加
- X-SID 请求头支持：新增从请求头 `X-SID` 获取会话ID的功能，优先级高于 cookie 中的 `sid`

### 测试添加
- TestForwardAuth_CookieSid：测试cookie是否正确转发
- TestForwardAuth_HeaderXSid：测试X-SID是否正确转发且优先级高于cookie
- TestForwardAuth_NoSid：测试无任何地方传sid时不转发

### 文档更新
- README 新增 X-SID 功能说明和使用示例

Close #27
